### PR TITLE
Don't add modules with undefined version to dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,10 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
           if (module.portableId.indexOf("external") !== -1) {
             logIfDebug(`GPJWP: Found external module: ${module.portableId}`);
             const moduleName = getNameFromPortableId(module.portableId);
-            modules[moduleName] = this.dependencyVersionMap[moduleName];
+            const dependencyVersion = this.dependencyVersionMap[moduleName];
+            if (dependencyVersion) {
+              modules[moduleName] = dependencyVersion;
+            }
           } else {
             logIfDebug(`GPJWP: Found module: ${module.portableId}`);
           }
@@ -89,7 +92,10 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
           if (module.portableId.indexOf("external") !== -1) {
             logIfDebug(`GPJWP: Found external module: ${module.portableId}`);
             const moduleName = getNameFromPortableId(module.portableId);
-            modules[moduleName] = this.dependencyVersionMap[moduleName];
+            const dependencyVersion = this.dependencyVersionMap[moduleName];
+            if (dependencyVersion) {
+              modules[moduleName] = dependencyVersion;
+            }
           } else {
             logIfDebug(`GPJWP: Found module: ${module.portableId}`);
           }


### PR DESCRIPTION
Prevents issues (webpack watch mode crash) with built-in node modules like `fs` and `path` being added to the dependencies list with 'undefined' as the version string.

Closes #4